### PR TITLE
Support for Mac-specific pip dependencies (psycopg)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ openpyxl
 Pillow
 pip
 pre-commit==2.19.0
-psycopg==3.0.11
+psycopg==3.0.11; sys_platform != 'darwin'
+psycopg[c]; sys_platform == 'darwin'
 psycopg2==2.9.3
 pytest==7.1.1
 python-binary-memcached==0.31.1


### PR DESCRIPTION
# Updated requirements.txt to support Macs

## Description

Dependency `psycopg` needs to be written as `psycopg[c]` to install properly on Macs.

## Type of change

Developer environment setup.

## How Has This Been Tested?

- [x] ~~Pytest: Added new test cases for your changes in `/src/python/test/test_endpoint.py`. `pytest` passes all test cases~~
- [x] Other: Please describe the tests that you ran to verify your changes

Dev environment settings don't need to be tested.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix or my feature works~~
- [x] ~~New and existing unit tests pass locally with my changes~~
